### PR TITLE
feat: add id to member join event

### DIFF
--- a/src/main/kotlin/me/markhc/hangoutbot/listeners/MemberMigration.kt
+++ b/src/main/kotlin/me/markhc/hangoutbot/listeners/MemberMigration.kt
@@ -43,6 +43,9 @@ fun migrationListeners(persistentData: PersistentData, guildService: GreetingSer
                     thumbnail {
                         url = member.avatar.url
                     }
+                    footer {
+                        text = "User ID: ${member.id.value}"
+                    }
                 }
 
                 guildService.addMessageToCache(member.asUser(), message)


### PR DESCRIPTION
# feat: add id to member join event

Add the member id to the member join embed. As there is no mention now, we can't easily find the id of a user.

Embed after this change:
![image](https://user-images.githubusercontent.com/1348165/98469465-b7c8af80-21d7-11eb-8d2c-7a3d59d499e0.png)
