### PR TITLE
Update year in license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 The Programmers Hangout
+Copyright (c) 2021 The Programmers Hangout
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The year in the `LICENSE.md` file is dated 2020. It's a small change but to keep the license dated, I changed it to 2021. 